### PR TITLE
refactor: divide handleValidationExceptions method into smaller sub-methods

### DIFF
--- a/src/main/java/com/example/usercrud/infrastructure/adapter/in/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/usercrud/infrastructure/adapter/in/web/exception/GlobalExceptionHandler.java
@@ -37,21 +37,40 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ValidationErrorResponse> handleValidationExceptions(
             MethodArgumentNotValidException ex) {
+        Map<String, String> errors = extractValidationErrors(ex);
+        ValidationErrorResponse errorResponse = createValidationErrorResponse(errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+    
+    /**
+     * Extracts validation errors from the MethodArgumentNotValidException.
+     * 
+     * @param ex the validation exception containing field errors
+     * @return a map of field names to error messages
+     */
+    private Map<String, String> extractValidationErrors(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors().forEach((error) -> {
             String fieldName = ((FieldError) error).getField();
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });
-        
-        ValidationErrorResponse errorResponse = new ValidationErrorResponse(
+        return errors;
+    }
+    
+    /**
+     * Creates a ValidationErrorResponse with the provided errors.
+     * 
+     * @param errors the validation errors map
+     * @return a fully constructed ValidationErrorResponse
+     */
+    private ValidationErrorResponse createValidationErrorResponse(Map<String, String> errors) {
+        return new ValidationErrorResponse(
             HttpStatus.BAD_REQUEST.value(),
             "Validation failed",
             errors,
             LocalDateTime.now()
         );
-        
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
     
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 📋 Descripción

Este PR resuelve el issue #21 refactorizando el método `handleValidationExceptions` de la clase `GlobalExceptionHandler` para mejorar la legibilidad y mantenibilidad del código.

## 🔧 Cambios realizados

- ✅ Extraído la lógica de extracción de errores de validación en el método privado `extractValidationErrors()`
- ✅ Extraído la creación de la respuesta de error en el método privado `createValidationErrorResponse()`
- ✅ Añadida documentación JavaDoc para los nuevos métodos privados
- ✅ Mantenida la funcionalidad original sin cambios en el comportamiento

## 🎯 Beneficios

1. **Mejor legibilidad**: El método principal ahora es más conciso y fácil de entender
2. **Separación de responsabilidades**: Cada método tiene una única responsabilidad clara
3. **Mantenibilidad mejorada**: Los cambios futuros serán más fáciles de implementar
4. **Documentación**: Los métodos privados están documentados explicando su propósito

## 📝 Notas para el revisor

- No se han introducido cambios en la lógica de negocio
- Los tests existentes deberían seguir pasando sin modificaciones
- El código sigue las convenciones de estilo del proyecto

Fixes #21